### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/cvelint.yml
+++ b/.github/workflows/cvelint.yml
@@ -71,6 +71,7 @@ jobs:
         continue-on-error: true
 
       - name: Commit changes
+        if: github.event_name != 'pull_request'
         uses: EndBug/add-and-commit@v10
         with:
           default_author: github_actions

--- a/.github/workflows/cvelint.yml
+++ b/.github/workflows/cvelint.yml
@@ -71,7 +71,7 @@ jobs:
         continue-on-error: true
 
       - name: Commit changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           default_author: github_actions
         env:


### PR DESCRIPTION
## Summary

- Updates `EndBug/add-and-commit` from v9 to v10 (Node.js 20 deprecation)
- Adds `if: github.event_name != 'pull_request'` to the commit step so it only runs on push/schedule events (the action fails on PRs because GitHub checks out a detached HEAD merge ref)
- Adds Dependabot config to keep GitHub Actions up to date

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>