### PR TITLE
fix: handle root commit edge case in squash-commits job

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -57,10 +57,17 @@ jobs:
             exit 0
           fi
 
+          # Check if KEEP_FROM is the root commit (no parent to squash into)
+          ROOT_COMMIT=$(git rev-list --max-parents=0 HEAD)
+          if [ "$KEEP_FROM" = "$ROOT_COMMIT" ]; then
+            echo "Oldest kept commit is already the root — nothing to squash"
+            exit 0
+          fi
+
           # Find the parent of the oldest kept commit
           SQUASH_UNTIL=$(git rev-parse "${KEEP_FROM}^" 2>/dev/null)
 
-          if [ -z "$SQUASH_UNTIL" ]; then
+          if [ -z "$SQUASH_UNTIL" ] || ! git cat-file -e "$SQUASH_UNTIL" 2>/dev/null; then
             echo "Nothing old enough to squash"
             exit 0
           fi


### PR DESCRIPTION
## Summary
- The monthly `squash-commits` maintenance job fails with exit code 128 when `KEEP_FROM` is the root commit (after a previous squash cycle)
- `git rev-parse "${KEEP_FROM}^"` fails silently, leaving `SQUASH_UNTIL` as an invalid ref that crashes the rebase
- Added explicit root commit detection and `git cat-file` validation before proceeding

## Test plan
- [x] Reproduced locally: confirmed `KEEP_FROM` == root commit `94924aed3`
- [x] Verified the fix exits cleanly with "Oldest kept commit is already the root" message
- [ ] Re-run the Maintenance workflow via `workflow_dispatch` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)